### PR TITLE
Relocate Kotlin + WildStacker support + API

### DIFF
--- a/api/src/main/java/net/weesli/rclaim/api/hook/ClaimStacker.java
+++ b/api/src/main/java/net/weesli/rclaim/api/hook/ClaimStacker.java
@@ -1,0 +1,18 @@
+package net.weesli.rclaim.api.hook;
+
+import net.weesli.rclaim.api.RClaimProvider;
+import net.weesli.rclaim.api.model.Claim;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public interface ClaimStacker {
+
+    default boolean availableArea(Player player, Location location) {
+        Chunk chunk = location.getChunk();
+        Claim claim = RClaimProvider.getClaimManager().getClaim(chunk);
+        if (claim == null) return false;
+        return claim.isOwner(player.getUniqueId());
+    }
+}
+

--- a/api/src/main/java/net/weesli/rclaim/api/hook/manager/StackerManager.java
+++ b/api/src/main/java/net/weesli/rclaim/api/hook/manager/StackerManager.java
@@ -1,0 +1,7 @@
+package net.weesli.rclaim.api.hook.manager;
+
+import net.weesli.rclaim.api.hook.ClaimStacker;
+
+public interface StackerManager {
+    ClaimStacker getIntegration();
+}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     // RoseStacker
     compileOnly("dev.rosewood:rosestacker:1.5.37")
 
+    // WildStacker
+    compileOnly("com.bgsoftware:WildStackerAPI:2025.2")
+
     implementation("com.github.Weesli:RozsConfig:1.2.1")
 
     implementation("com.tcoded:FoliaLib:0.5.1")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -123,6 +123,8 @@ tasks.shadowJar {
 
     relocate("org.bstats", "net.weesli.libs.bstats")
     relocate("com.tcoded.folialib", "net.weesli.libs.folialib")
+    // Kotlin bad! Kotlin is used in other plugins that can create conflicts, just relocate it
+    relocate("kotlin", "net.weesli.libs.kotlin")
 
 }
 

--- a/plugin/src/main/java/net/weesli/rclaim/RClaim.java
+++ b/plugin/src/main/java/net/weesli/rclaim/RClaim.java
@@ -18,7 +18,7 @@ import net.weesli.rclaim.api.status.ClaimStatusService;
 import net.weesli.rclaim.event.ClaimLifecycleListener;
 import net.weesli.rclaim.event.ClaimPermissionListener;
 import net.weesli.rclaim.event.ClaimStatusListener;
-import net.weesli.rclaim.hook.other.HRoseStacker;
+import net.weesli.rclaim.hook.stacker.HRoseStacker;
 import net.weesli.rclaim.input.TextInputManager;
 import net.weesli.rclaim.manager.CacheManagerImpl;
 import net.weesli.rclaim.command.CommandManager;
@@ -68,6 +68,7 @@ public final class RClaim extends JavaPlugin {
     private SpawnerManagerImpl spawnerManager;
     private MinionsManagerImpl minionsManager;
     private CombatManagerImpl combatManager;
+    private StackerManagerImpl stackerManager;
 
 
    @Getter private static RClaim instance;
@@ -89,6 +90,7 @@ public final class RClaim extends JavaPlugin {
         hologramManager = new HologramManagerImpl();
         uiManager = new UIManager();
         combatManager = new CombatManagerImpl();
+        stackerManager = new StackerManagerImpl(this);
         claimManager = new ClaimManagerImpl();
         tagManager = new TagManagerImpl();
         textInputManager = new TextInputManager(this);
@@ -105,8 +107,6 @@ public final class RClaim extends JavaPlugin {
         new MapLoader();
         // initialize betterRTP hook if plugin is enabled
         if (getServer().getPluginManager().isPluginEnabled("BetterRTP")) new HBetterRTP(this);
-        // initialize roseStacker hook if plugin is enabled
-        if (getServer().getPluginManager().isPluginEnabled("RoseStacker")) new HRoseStacker(this);
 
         // register RozsLibService in this plugin
         RozsLibService.start(this);

--- a/plugin/src/main/java/net/weesli/rclaim/hook/manager/StackerManagerImpl.java
+++ b/plugin/src/main/java/net/weesli/rclaim/hook/manager/StackerManagerImpl.java
@@ -1,0 +1,28 @@
+package net.weesli.rclaim.hook.manager;
+
+import net.weesli.rclaim.RClaim;
+import net.weesli.rclaim.api.hook.ClaimStacker;
+import net.weesli.rclaim.api.hook.manager.StackerManager;
+import net.weesli.rclaim.hook.spawner.SilkSpawner;
+import net.weesli.rclaim.hook.spawner.SpawnerMeta;
+import net.weesli.rclaim.hook.stacker.HRoseStacker;
+import net.weesli.rclaim.hook.stacker.HWildStacker;
+import org.bukkit.Bukkit;
+
+public class StackerManagerImpl implements StackerManager {
+
+    private ClaimStacker stackerIntegration;
+
+    public StackerManagerImpl(RClaim plugin) {
+        if (Bukkit.getPluginManager().isPluginEnabled("RoseStacker")){
+            stackerIntegration = new HRoseStacker(plugin);
+        } else if (Bukkit.getPluginManager().isPluginEnabled("WildStacker")) {
+            stackerIntegration = new HWildStacker(plugin);
+        }
+    }
+
+    @Override
+    public ClaimStacker getIntegration() {
+        return this.stackerIntegration;
+    }
+}

--- a/plugin/src/main/java/net/weesli/rclaim/hook/stacker/HRoseStacker.java
+++ b/plugin/src/main/java/net/weesli/rclaim/hook/stacker/HRoseStacker.java
@@ -1,10 +1,12 @@
-package net.weesli.rclaim.hook.other;
+package net.weesli.rclaim.hook.stacker;
 
 import dev.rosewood.rosestacker.event.BlockStackEvent;
 import dev.rosewood.rosestacker.event.BlockUnstackEvent;
 import dev.rosewood.rosestacker.event.SpawnerStackEvent;
 import dev.rosewood.rosestacker.event.SpawnerUnstackEvent;
+import net.weesli.rclaim.RClaim;
 import net.weesli.rclaim.api.RClaimProvider;
+import net.weesli.rclaim.api.hook.ClaimStacker;
 import net.weesli.rclaim.api.model.Claim;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -15,17 +17,10 @@ import org.bukkit.plugin.Plugin;
 
 import static net.weesli.rclaim.config.lang.LangConfig.sendMessageToPlayer;
 
-public class HRoseStacker implements Listener {
+public class HRoseStacker implements Listener, ClaimStacker {
 
-    public HRoseStacker(Plugin plugin) {
+    public HRoseStacker(RClaim plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-    }
-
-    private boolean availableArea(Player player, Location location) {
-        Chunk chunk = location.getChunk();
-        Claim claim = RClaimProvider.getClaimManager().getClaim(chunk);
-        if (claim == null) return false;
-        return claim.isOwner(player.getUniqueId());
     }
 
     @EventHandler
@@ -41,7 +36,7 @@ public class HRoseStacker implements Listener {
         if (event.getPlayer() == null) return;
         if (!availableArea(event.getPlayer(), event.getStack().getLocation())) {
             event.setCancelled(true);
-            sendMessageToPlayer("YOU_CANT_STACK_BLOCKS", event.getPlayer());
+            sendMessageToPlayer("YOU_CANT_UNSTACK_BLOCKS", event.getPlayer());
         }
     }
 
@@ -58,7 +53,7 @@ public class HRoseStacker implements Listener {
         if (event.getPlayer() == null) return;
         if (!availableArea(event.getPlayer(), event.getStack().getLocation())) {
             event.setCancelled(true);
-            sendMessageToPlayer("YOU_CANT_STACK_SPAWNERS", event.getPlayer());
+            sendMessageToPlayer("YOU_CANT_UNSTACK_SPAWNERS", event.getPlayer());
         }
     }
 }

--- a/plugin/src/main/java/net/weesli/rclaim/hook/stacker/HWildStacker.java
+++ b/plugin/src/main/java/net/weesli/rclaim/hook/stacker/HWildStacker.java
@@ -1,0 +1,57 @@
+package net.weesli.rclaim.hook.stacker;
+
+import com.bgsoftware.wildstacker.api.events.*;
+import dev.rosewood.rosestacker.event.BlockStackEvent;
+import dev.rosewood.rosestacker.event.BlockUnstackEvent;
+import dev.rosewood.rosestacker.event.SpawnerStackEvent;
+import net.weesli.rclaim.RClaim;
+import net.weesli.rclaim.api.hook.ClaimStacker;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+import static net.weesli.rclaim.config.lang.LangConfig.sendMessageToPlayer;
+
+public class HWildStacker implements Listener, ClaimStacker {
+
+    public HWildStacker(RClaim plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void blockStack(BarrelPlaceEvent event) {
+        if (!availableArea(event.getPlayer(), event.getBarrel().getLocation())) {
+            event.setCancelled(true);
+            sendMessageToPlayer("YOU_CANT_STACK_BLOCKS", event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void blockUnstack(BarrelUnstackEvent event) {
+        if (event.getUnstackSource() == null) return;
+        if (!(event.getUnstackSource() instanceof Player player)) return;
+        if (!availableArea(player, event.getBarrel().getLocation())) {
+            event.setCancelled(true);
+            sendMessageToPlayer("YOU_CANT_UNSTACK_BLOCKS", player);
+        }
+    }
+
+    @EventHandler
+    public void SpawnerStack(SpawnerPlaceEvent event) {
+        if (!availableArea(event.getPlayer(), event.getSpawner().getLocation())) {
+            event.setCancelled(true);
+            sendMessageToPlayer("YOU_CANT_STACK_SPAWNERS", event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void spawnerUnstack(SpawnerUnstackEvent event) {
+        if (event.getUnstackSource() == null) return;
+        if (!(event.getUnstackSource() instanceof Player player)) return;
+        if (!availableArea(player, event.getSpawner().getLocation())) {
+            event.setCancelled(true);
+            sendMessageToPlayer("YOU_CANT_UNSTACK_BLOCKS", player);
+        }
+    }
+}

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -25,6 +25,7 @@ softdepend:
   - FancyHolograms
   - DeluxeCombat
   - RoseStacker
+  - WildStacker
 permissions:
   rclaim.admin.clearclaim:
     description: Permission to clear all claims of player

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,5 +53,8 @@ dependencyResolutionManagement {
         }
         // FoliaLib
         maven("https://repo.tcoded.com/releases")
+
+        // WildStacker
+        maven("https://repo.bg-software.com/repository/api/")
     }
 }


### PR DESCRIPTION
This will also fix kotlin shadowing:
```[21:54:27] [Server thread/INFO]: [eco] Scanning for conflicts...
[21:54:27] [Server thread/WARN]: [eco] RClaim will likely conflict with eco! Reason: Kotlin shaded into jar
[21:54:27] [Server thread/WARN]: [eco] You can fix the conflicts by either removing the conflicting plugins, or by asking on the support discord to have them patched!
[21:54:27] [Server thread/WARN]: [eco] Only remove potentially conflicting plugins if you see Loader Constraint Violation / LinkageError anywhere```