### PR TITLE
Fix MySQL connection

### DIFF
--- a/plugin/src/main/java/net/weesli/rclaim/database/AbstractDatabase.java
+++ b/plugin/src/main/java/net/weesli/rclaim/database/AbstractDatabase.java
@@ -16,22 +16,17 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.*;
 
-public abstract class AbstractDatabase extends Database implements ClaimDatabase {
+public abstract class AbstractDatabase implements ClaimDatabase {
 
-    private final ConnectionInfo info;
     private final Gson gson = GsonProvider.getGson();
-    private Connection connection;
+    private final Connection connection;
 
     @SneakyThrows
     public AbstractDatabase(ConnectionInfo info) {
-        super(info);
-        this.info = info;
-        connect();
-    }
-    public void connect() {
         connection = DatabaseFactory.createConnection(info);
         createTable();
     }
+
     @SneakyThrows
     private void createTable() {
         String sql = tableSQL();

--- a/plugin/src/main/java/net/weesli/rclaim/database/MySQLStorage.java
+++ b/plugin/src/main/java/net/weesli/rclaim/database/MySQLStorage.java
@@ -7,14 +7,13 @@ import net.weesli.rozslib.enums.DatabaseType;
 
 public class MySQLStorage extends AbstractDatabase {
 
-    public MySQLStorage(){
+    public MySQLStorage() {
         super(new ConnectionInfo(
                 DatabaseType.MySQL,
-                String.format("jdbc:mysql://%s:%s@%s:%s/",
-                        ConfigLoader.getConfig().getDatabase().getUsername(),
-                        ConfigLoader.getConfig().getDatabase().getPassword(),
+                String.format("jdbc:mysql://%s:%s/%s",
                         ConfigLoader.getConfig().getDatabase().getHost(),
-                        ConfigLoader.getConfig().getDatabase().getPort()),
+                        ConfigLoader.getConfig().getDatabase().getPort(),
+                        ConfigLoader.getConfig().getDatabase().getDatabase()),
                 ConfigLoader.getConfig().getDatabase().getUsername(),
                 ConfigLoader.getConfig().getDatabase().getPassword(),
                 ConfigLoader.getConfig().getDatabase().getDatabase()


### PR DESCRIPTION
The standard mysql url is `jdbc:mysql://<hostname>:<port>/<database>`
Also, the extension of `Database` class made the plugin load 2 connections, with one being useless and consuming resources. It also failed because of it.